### PR TITLE
use git exit code instead of checking command output

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -78,7 +78,7 @@ fi
 
 # Check that this is your first time running this script. If not, we'll reset
 # all local state and restart from scratch!
-if [[ $(git diff --stat) != '' ]]; then
+if ! git diff-index --quiet --no-ext-diff HEAD --; then
   echo "It looks like you may have run this script before! Re-running it will reset any
   changes you've made to backend.tf and provider.tf."
   echo


### PR DESCRIPTION
If a user is running the setup script for the second time, we need to clear out existing state and start from a clean slate. To do this, we check to see if there are any changes, then give the user a warning so they can exit if they don't want their changes to be cleared.

Previously, we did this check by checking that the output of `git diff --stat` was empty. However, this is a bit brittle. Sometimes there may be output from `git diff --stat` - like warning about a git config issue - that's not related to actual changes, which results in weird confusing output that the user isn't sure if they need to act upon.

Instead, let's use the `--quiet` flag, which tells git to suppress all visible output and exit with 0 if there are no changes and 1 if there are.