### PR TITLE
Improve minimum version handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repo contains two main things:
 
 ## Requirements
 
-- Terraform 0.13 or higher
+- Terraform 0.14 or higher
 - The ability to run a bash script in your terminal
 - [`sed`](https://www.gnu.org/software/sed/)
 - [`curl`](https://curl.se/)

--- a/backend.tf
+++ b/backend.tf
@@ -9,5 +9,5 @@ terraform {
     }
   }
 
-  required_version = ">= 0.13.0"
+  required_version = ">= 0.14.0"
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -47,10 +47,12 @@ for tool in "${req_tools[@]}"; do
   fi
 done
 
-# Check for required Terraform version
-if ! terraform version -json | jq -r '.terraform_version' &> /dev/null; then
+# Check for required Terraform version (0.Version.x)
+minimumTerraformVersion=14
+installedTerraformVersion=$(terraform version -json | jq -r '.terraform_version' | cut -d '.' -f 2)
+if [ $installedTerraformVersion -lt $minimumTerraformVersion ]; then
   echo
-  fail "Terraform 0.13 or later is required for this setup script!"
+  fail "Terraform 0.$minimumTerraformVersion.x or later is required for this setup script!"
   echo "You are currently running:"
   terraform version
   exit 1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -47,9 +47,17 @@ for tool in "${req_tools[@]}"; do
   fi
 done
 
-# Check for required Terraform version (0.Version.x)
-minimumTerraformVersion=14
-installedTerraformVersion=$(terraform version -json | jq -r '.terraform_version' | cut -d '.' -f 2)
+# Get the minimum required version of Terraform
+minimumTerraformMajorVersion=0
+minimumTerraformMinorVersion=14
+minimumTerraformVersion=$(($minimumTerraformMajorVersion * 1000 + $minimumTerraformMinorVersion))
+
+# Get the current version of Terraform
+installedTerraformMajorVersion=$(terraform version -json | jq -r '.terraform_version' | cut -d '.' -f 1)
+installedTerraformMinorVersion=$(terraform version -json | jq -r '.terraform_version' | cut -d '.' -f 2)
+installedTerraformVersion=$(($installedTerraformMajorVersion * 1000 + $installedTerraformMinorVersion))
+
+# Check we meet the minimum required version
 if [ $installedTerraformVersion -lt $minimumTerraformVersion ]; then
   echo
   fail "Terraform 0.$minimumTerraformVersion.x or later is required for this setup script!"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -60,7 +60,7 @@ installedTerraformVersion=$(($installedTerraformMajorVersion * 1000 + $installed
 # Check we meet the minimum required version
 if [ $installedTerraformVersion -lt $minimumTerraformVersion ]; then
   echo
-  fail "Terraform 0.$minimumTerraformVersion.x or later is required for this setup script!"
+  fail "Terraform $minimumTerraformMajorVersion.$minimumTerraformMinorVersion.x or later is required for this setup script!"
   echo "You are currently running:"
   terraform version
   exit 1


### PR DESCRIPTION
With recent changes Terraform v0.14 or newer is required. Updated the various files to reflect this requirement.

In addition updated the script to explicitly check the version and made it easier to read / update the minimum version requirement.

This addresses issue #12 