### PR TITLE
Properly return error when using a Terraform version not supported by the organization

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -127,15 +127,15 @@ REQUEST_BODY
 }
 
 response=$(setup)
+err=$(echo $response | jq -r '.errors')
 
-if [[ $(echo $response | jq -r '.errors') != null ]]; then
-  fail "An unknown error occurred: ${response}"
-  exit 1
-fi
-
-api_error=$(echo $response | jq -r '.error')
-if [[ $api_error != null ]]; then
-  fail "\n${api_error}"
+if [[ $err != null ]]; then
+  err_msg=$(echo $err | jq -r '.[0].detail')
+  if [[ $err_msg != null ]]; then
+    fail "An error occurred: ${err_msg}"
+  else 
+    fail "An unknown error occurred: ${err}"
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
## Description
`egrep` the output of `terraform version`, if it includes `alpha` or `beta`, will prevent the script from being run. This is a result of the API throwing an error if a development version is used. TFC supports development versions if they are enabled for your organization. However since a new organization is created running `scripts/setup.sh` it will not have beta versions enabled. So this is to preemptively warn the user before even interacting with the API. 

## To Test
Ensure the Terraform version in your PATH is development (either a beta or alpha version), you should see:

```sh
$ terraform version
Terraform vX.X.X-betaY
on darwin_amd64
```

In my case I uninstalled the release version and moved the development version to `/usr/local/bin`

Then you can run the setup script:

```sh
./scripts/setup.sh
```

And see:

```sh
Development versions of Terraform are not supported by this script, please use a release version >= 0.13.
You are currently running:
Terraform v1.1.0-beta1
on darwin_amd64
```