### PR TITLE
use /usr/bin/env in shebang

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 info() {


### PR DESCRIPTION
Some environment (e.g. NixOS) does not have `/bin/bash`, so using `/usr/bin/env` is more portable.