### PR TITLE
Escaped spaces in CREDENTIALS_FILE path

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -69,7 +69,7 @@ TERRAFORM_VERSION=$(terraform version -json | jq -r '.terraform_version')
 # and you hopefully do not need this Getting Started project if you're using one
 # already!
 CREDENTIALS_FILE="$HOME/.terraform.d/credentials.tfrc.json"
-TOKEN=$(jq -j --arg h "$HOST" '.credentials[$h].token' $CREDENTIALS_FILE)
+TOKEN=$(jq -j --arg h "$HOST" '.credentials[$h].token' "$CREDENTIALS_FILE")
 if [[ ! -f $CREDENTIALS_FILE || $TOKEN == null ]]; then
   fail "We couldn't find a token in the Terraform credentials file at $CREDENTIALS_FILE."
   fail "Please run 'terraform login', then run this setup script again."


### PR DESCRIPTION
When running the setup.sh script, I ran into an error because I had a space in my username for my home directory when using jq.

### The Error Output:
```
./scripts/setup.sh
jq: error: Could not open file C:/Users/William: No such file or directory
jq: error: Could not open file Lin/.terraform.d/credentials.tfrc.json: No such file or directory
```