### PR TITLE
Fix Credentials Folder Location for Windows

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -78,14 +78,13 @@ TERRAFORM_VERSION=$(terraform version -json | jq -r '.terraform_version')
 # account - but we do this to avoid embedding a Go binary in this simple script
 # and you hopefully do not need this Getting Started project if you're using one
 # already!
-CREDS_FOLDER="$HOME/."
+CREDENTIALS_FILE="$HOME/.terraform.d/credentials.tfrc.json"
 
 # Credentials are located in App/Data/Roaming on Windows
-if [[ "$OSTYPE" =~ ^msys ]]; then
-    CREDS_FOLDER="$APPDATA/"
+if [[ "$OSTYPE" =~ ^msys || "$OSTYPE" =~ ^cygwin || "$OSTYPE" =~ ^win32  ]]; then
+    CREDENTIALS_FILE="$APPDATA/terraform.d/credentials.tfrc.json"
 fi
 
-CREDENTIALS_FILE="${CREDS_FOLDER}terraform.d/credentials.tfrc.json"
 TOKEN=$(jq -j --arg h "$HOST" '.credentials[$h].token' "$CREDENTIALS_FILE")
 if [[ ! -f $CREDENTIALS_FILE || $TOKEN == null ]]; then
   fail "We couldn't find a token in the Terraform credentials file at $CREDENTIALS_FILE."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -78,7 +78,14 @@ TERRAFORM_VERSION=$(terraform version -json | jq -r '.terraform_version')
 # account - but we do this to avoid embedding a Go binary in this simple script
 # and you hopefully do not need this Getting Started project if you're using one
 # already!
-CREDENTIALS_FILE="$HOME/.terraform.d/credentials.tfrc.json"
+CREDS_FOLDER="$HOME/."
+
+# Credentials are located in App/Data/Roaming on Windows
+if [[ "$OSTYPE" =~ ^msys ]]; then
+    CREDS_FOLDER="$APPDATA/"
+fi
+
+CREDENTIALS_FILE="${CREDS_FOLDER}terraform.d/credentials.tfrc.json"
 TOKEN=$(jq -j --arg h "$HOST" '.credentials[$h].token' "$CREDENTIALS_FILE")
 if [[ ! -f $CREDENTIALS_FILE || $TOKEN == null ]]; then
   fail "We couldn't find a token in the Terraform credentials file at $CREDENTIALS_FILE."


### PR DESCRIPTION
## Description
The setup script fails with the following message when running it on Windows using GitBash. This is reported in issue #27 
```sh
$ ./scripts/setup.sh
jq: error: Could not open file C:/Users/Claire Knutson/.terraform.d/credentials.tfrc.json: No such file or directory
```
The reason is that the terraform login command is[ using the $APPDATA environment variable](https://github.com/hashicorp/terraform/blob/0c7fda19064fa929a29c9aed8fb507d9daac40cd/internal/command/cliconfig/config_windows.go#L41), not `$HOME` when run on a Windows operating system. In conjunction with using a different folder, the subfolder name `terraform.d` is [not prefixed with a period](https://github.com/hashicorp/terraform/blob/0c7fda19064fa929a29c9aed8fb507d9daac40cd/internal/command/cliconfig/config_windows.go#L34) like it is for Unix operating systems.

## Testing plan
1. Run the `./scripts/setup.sh` using the following
- GitBash on Windows
- Cygwin on Windows
- Ubuntu using WSL2

2. Script should show a message beginning with `It looks like you may have run this script before!`


Fixes #27
Fixes #22
Fixes #20 