### PR TITLE
Add copywrite headers and GH Action

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,14 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2018
+
+  # (OPTIONAL) A list of globs that should not have copyright/license headers.
+  # Supports doublestar glob patterns for more flexibility in defining which
+  # files or folders should be ignored
+  header_ignore = [
+    # "vendors/**",
+    # "**autogen**",
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: Copywrite
+
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  copywrite:
+    name: Run Header Copyright
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+
+      - name: Install Copywrite
+        id: install
+        uses: hashicorp/setup-copywrite@v1.0.0
+
+      - name: Output Installed Copywrite Version
+        run: echo "Installed Copywrite CLI ${{steps.install.outputs.version}}"
+
+      - name: Run Copywrite Header Compliance
+        run: copywrite headers --plan

--- a/backend.tf
+++ b/backend.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # The block below configures Terraform to use the 'remote' backend with Terraform Cloud.
 # For more information, see https://www.terraform.io/docs/backends/types/remote.html
 terraform {

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # The following configuration uses a provider which provisions [fake] resources
 # to a fictitious cloud vendor called "Fake Web Services". Configuration for
 # the fakewebservices provider can be found in provider.tf.

--- a/provider.tf
+++ b/provider.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # The following variable is used to configure the provider's authentication
 # token. You don't need to provide a token on the command line to apply changes,
 # though: using the remote backend, Terraform will execute remotely in Terraform

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 set -euo pipefail
 
 info() {


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? What are the key new features or breaking changes? -->
* HashiCorp public repos will begin being scanned for source code copyright headers starting Feb.1, 2023. We want to make sure this repo is in adherence to the automated checks.
* Add Github action which will run a check on the repo during pull requests. This is simply a validation and will not automatically correct any source.
* Bring repo up-to-date using the `copywrite` CLI.

### :link: External Links

<!-- Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section. -->
* [GH Action](https://github.com/marketplace/actions/setup-copywrite)
* `copywrite` [CLI](https://github.com/hashicorp/copywrite#getting-started)
