### PR TITLE
Bump Readme required version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repo contains two main things:
 
 ## Requirements
 
-- Terraform 0.14 or higher
+- Terraform 1.1.2 or higher
 - The ability to run a bash script in your terminal
 - [`sed`](https://www.gnu.org/software/sed/)
 - [`curl`](https://curl.se/)


### PR DESCRIPTION
* The required version of terraform in `version.tf` is 1.1.2
* This change updates the Readme to reflect the configured `required_version`